### PR TITLE
Removing planB constraint when checking if safari supports video

### DIFF
--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -234,8 +234,7 @@ export default class BrowserCapabilities extends BrowserDetection {
         // Older versions of Safari using webrtc/adapter do not support video
         // due in part to Safari only supporting H264 and the bridge sending VP8
         // Newer Safari support VP8 and other WebRTC features.
-        return !this.isSafariWithWebrtc()
-            || (this.isSafariWithVP8() && this.usesPlanB());
+        return !this.isSafariWithWebrtc() || (this.isSafariWithVP8());
     }
 
     /**


### PR DESCRIPTION
since video works with unified plan as well until simulcast is disabled