### PR TITLE
VS-2253 Configurable bitrate, increased frozen track timouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ deploy-local.sh
 lib-jitsi-meet.*
 npm-*.log
 .sync-config.cson
+/.vscode
+/.jshintrc

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -180,6 +180,12 @@ export default function TraceablePeerConnection(
         this._peerMutedChanged);
     this.options = options;
 
+    logger.log("Initializing TraceablePeerConnection with options: " +  JSON.stringify(this.options, null, 2));
+
+    // force to disable simulcast, no matter what...
+    this.options.disableSimulcast = true;
+    logger.log('Simulcast was forced to be disabled.');
+
     this.peerconnection
         = new RTCUtils.RTCPeerConnectionType(iceConfig, constraints);
     this.updateLog = [];
@@ -617,7 +623,7 @@ TraceablePeerConnection.prototype._remoteTrackAdded = function(stream, track) {
     const streamId = RTC.getStreamID(stream);
     const mediaType = track.kind;
 
-    logger.info(`${this} remote track added:`, streamId, mediaType);
+    logger.log(`${this} remote track added:`, streamId, mediaType);
 
     // look up an associated JID for a stream id
     if (!mediaType) {

--- a/modules/RTC/TraceablePeerConnection.js
+++ b/modules/RTC/TraceablePeerConnection.js
@@ -182,10 +182,6 @@ export default function TraceablePeerConnection(
 
     logger.log("Initializing TraceablePeerConnection with options: " +  JSON.stringify(this.options, null, 2));
 
-    // force to disable simulcast, no matter what...
-    this.options.disableSimulcast = true;
-    logger.log('Simulcast was forced to be disabled.');
-
     this.peerconnection
         = new RTCUtils.RTCPeerConnectionType(iceConfig, constraints);
     this.updateLog = [];

--- a/modules/browser/BrowserCapabilities.js
+++ b/modules/browser/BrowserCapabilities.js
@@ -234,8 +234,7 @@ export default class BrowserCapabilities extends BrowserDetection {
         // Older versions of Safari using webrtc/adapter do not support video
         // due in part to Safari only supporting H264 and the bridge sending VP8
         // Newer Safari support VP8 and other WebRTC features.
-        return !this.isSafariWithWebrtc()
-            || (this.isSafariWithVP8() && this.usesPlanB());
+        return !this.isSafariWithWebrtc() || (this.isSafariWithVP8());
     }
 
     /**

--- a/modules/connectivity/ConnectionQuality.js
+++ b/modules/connectivity/ConnectionQuality.js
@@ -57,25 +57,40 @@ const kSimulcastFormats = [
         min: 30 }
 ];
 
+function getUrlParameterOrNull(paramName) {
+    const params = new URLSearchParams(window.location.search);
+    return params.get(paramName) || null;
+}
+
+function getUrlParameterAsNumberOrNull(paramName) {
+    const param = getUrlParameterOrNull(paramName);
+    return Number(param) || null;
+}
+
 /**
  * The maximum bitrate to use as a measurement against the participant's current
  * bitrate. This cap helps in the cases where the participant's bitrate is high
  * but not enough to fulfill high targets, such as with 1080p.
  */
-const MAX_TARGET_BITRATE = 2500;
+const MAX_TARGET_BITRATE =
+    getUrlParameterAsNumberOrNull('maxBitrateTarget') || 900;
+// pass ?maxBitrateTarget=<number> to set. defaults to 900.
 
 /**
  * The initial bitrate for video in kbps.
  */
-let startBitrate = 800;
-
+let startBitrate =
+    getUrlParameterAsNumberOrNull('startBitrate') || 300;
+// pass ?startBitrate=<number> to set. defaults to 300.
 
 /**
  * The current cap (in kbps) put on the video stream (or null if there isn't
  * a cap).  If there is a cap, we'll take it into account when calculating
  * the current quality.
  */
-let videoBitrateCap = null;
+let videoBitrateCap =
+    getUrlParameterAsNumberOrNull('videoBitrateCap') || null;
+// pass ?videoBitrateCap=<number> to set. defaults to null which means no cap (see JSDoc)
 
 /**
  * Gets the expected bitrate (in kbps) in perfect network conditions.

--- a/modules/connectivity/ParticipantConnectionStatus.js
+++ b/modules/connectivity/ParticipantConnectionStatus.js
@@ -10,20 +10,20 @@ import Statistics from '../statistics/statistics';
 const logger = getLogger(__filename);
 
 /**
- * Default value of 500 milliseconds for
+ * Default value of 120000 milliseconds for
  * {@link ParticipantConnectionStatus.outOfLastNTimeout}.
  *
  * @type {number}
  */
-const DEFAULT_NOT_IN_LAST_N_TIMEOUT = 500;
+const DEFAULT_NOT_IN_LAST_N_TIMEOUT = 120000;
 
 /**
- * Default value of 2000 milliseconds for
+ * Default value of 120000 milliseconds for
  * {@link ParticipantConnectionStatus.rtcMuteTimeout}.
  *
  * @type {number}
  */
-const DEFAULT_RTC_MUTE_TIMEOUT = 2000;
+const DEFAULT_RTC_MUTE_TIMEOUT = 120000;
 
 /**
  * The time to wait a track to be restored. Track which was out of lastN
@@ -33,7 +33,7 @@ const DEFAULT_RTC_MUTE_TIMEOUT = 2000;
  * interrupted.
  * @type {number}
  */
-const DEFAULT_RESTORING_TIMEOUT = 5000;
+const DEFAULT_RESTORING_TIMEOUT = 120000;
 
 /**
  * Participant connection statuses.
@@ -605,7 +605,7 @@ export default class ParticipantConnectionStatusHandler {
             this._clearRestoringTimer(id);
         }
 
-        logger.debug(
+        logger.log(
             `Figure out conn status for ${id}, is video muted: ${
                 isVideoMuted} is active(jvb): ${
                 isConnActiveByJvb} video track frozen: ${

--- a/modules/statistics/RTPStatsCollector.js
+++ b/modules/statistics/RTPStatsCollector.js
@@ -781,6 +781,11 @@ StatsCollector.prototype._processAndEmitReport = function() {
         bitrateUpload += ssrcStats.bitrate.upload;
 
         // collect resolutions and framerates
+        if (!ssrc){
+            // preventing 'SSRC undefined is not a number' errors in Safari.
+            logger.debug('Stats collection failed. No SSRC is given. PeerConnection: ' + this.peerconnection);
+            return 
+        }
         const track = this.peerconnection.getTrackBySSRC(ssrc);
 
         if (track) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7407,11 +7407,11 @@
       }
     },
     "rtcpeerconnection-shim": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.5.tgz",
-      "integrity": "sha512-2oLVHZZMk/TsU9JqgrQYwdkOsDOeIalM3STqWjI1LtXrSrInHdig6CysSoTmEublMxnuy/F2i5NXE6tiIh9tZQ==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
+      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
       "requires": {
-        "sdp": "^2.2.0"
+        "sdp": "^2.6.0"
       }
     },
     "run-async": {
@@ -7498,9 +7498,9 @@
       }
     },
     "sdp": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.6.0.tgz",
-      "integrity": "sha512-/q5nUDSqvfh+P5pvb4Ez1IsF6F9aLLgslHrSDSltqvUuS7raTY9ROjbGJTyvGSYRs99FY59c8Od1lT7WVaiNAw=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
+      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
     },
     "sdp-transform": {
       "version": "2.3.0",
@@ -9052,11 +9052,11 @@
       }
     },
     "webrtc-adapter": {
-      "version": "github:webrtc/adapter#1eec19782b4058d186341263e7d049cea3e3290a",
-      "from": "webrtc-adapter@github:webrtc/adapter#1eec19782b4058d186341263e7d049cea3e3290a",
+      "version": "github:kecskesk/adapter#aadf242ef03a39d203da4e544ffd6a104a7bf851",
+      "from": "github:kecskesk/adapter#aadf242ef03a39d203da4e544ffd6a104a7bf851",
       "requires": {
-        "rtcpeerconnection-shim": "^1.1.13",
-        "sdp": "^2.3.0"
+        "rtcpeerconnection-shim": "^1.2.15",
+        "sdp": "^2.9.0"
       }
     },
     "which": {


### PR DESCRIPTION
**Note:**
This code changes are actually went production with https://cabidev.atlassian.net/browse/VS-2253.
See: 
- https://bitbucket.org/cabidev/cabiofbiz/pull-requests/4768
- https://bitbucket.org/cabionline/www/pull-requests/1004

**Changes:**
- allowing video for browsers using unified-plan
- make bitrate configurable both from URL parameters and part of the options parameter
- increase frozen track timeouts
- getting rid of 'SSRC undefined is not a number' errors in safari
- some improved logging

