### PR TITLE
VS-2611

### DIFF
--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -287,7 +287,7 @@ export default class ChatRoom extends Listenable {
         !this.connection.isUsingWebSocket && this.connection.flush();
         try {
             this.connection.send(pres);
-        } catch(error) {
+        } catch (error) {
             // we ignore this error since it is caused by asynch logout
             if (error.message !== 'Not connected') {
                 throw error;

--- a/modules/xmpp/ChatRoom.js
+++ b/modules/xmpp/ChatRoom.js
@@ -285,7 +285,14 @@ export default class ChatRoom extends Listenable {
         // possible.
         // FIXME do not use Strophe.Connection in the ChatRoom directly
         !this.connection.isUsingWebSocket && this.connection.flush();
-        this.connection.send(pres);
+        try {
+            this.connection.send(pres);
+        } catch(error) {
+            // we ignore this error since it is caused by asynch logout
+            if (error.message !== 'Not connected') {
+                throw error;
+            }
+        }
         this.connection.flush();
     }
 


### PR DESCRIPTION
It seems that this error is caused by either exiting the conference or losing connection. Since in the first case we are already leaving and in the second case we are already required to refresh and also this is a very rare error that only happens because of asynch methods, I changed the code so it ignores this error.